### PR TITLE
Pass through all operators for G, R, S, and W

### DIFF
--- a/lazyviewport.py
+++ b/lazyviewport.py
@@ -15,7 +15,7 @@ class LazyViewPortMove(bpy.types.Operator):
 
     def execute(self, context):
         set_active_tool('builtin.move')
-        return {'FINISHED'}
+        return {'PASS_THROUGH'}
 
 
 class LazyViewPortRotate(bpy.types.Operator):
@@ -25,7 +25,7 @@ class LazyViewPortRotate(bpy.types.Operator):
 
     def execute(self, context):
         set_active_tool('builtin.rotate')
-        return {'FINISHED'}
+        return {'PASS_THROUGH'}
 
 
 class LazyViewPortScale(bpy.types.Operator):
@@ -35,7 +35,7 @@ class LazyViewPortScale(bpy.types.Operator):
 
     def execute(self, context):
         set_active_tool('builtin.scale')
-        return {'FINISHED'}
+        return {'PASS_THROUGH'}
 
 
 class LazyViewPortSelect(bpy.types.Operator):
@@ -45,7 +45,7 @@ class LazyViewPortSelect(bpy.types.Operator):
 
     def execute(self, context):
         set_active_tool('builtin.select_box')
-        return {'FINISHED'}
+        return {'PASS_THROUGH'}
 
 
 def set_active_tool(tool_name):


### PR DESCRIPTION
Instead of replacing the keymapping, this will execute all keymappings on those 4 keys, which provides a less intrusive plugin.